### PR TITLE
fix bugs when using make -B

### DIFF
--- a/bsp/abstract-machine/Makefile
+++ b/bsp/abstract-machine/Makefile
@@ -14,6 +14,7 @@ include $(AM_HOME)/Makefile
 $(RTCONFIG_H):
 	touch $@
 	scons --useconfig=.config
+	if [ "`sed -n '3p' $@`"x = x ]; then sed -i -e '2a#include "extra.h"' $@; fi
 
 init: $(RTCONFIG_H)
 	scons -c
@@ -21,7 +22,6 @@ init: $(RTCONFIG_H)
 	cat $(FILE_TMP) | grep -o '[^ ]*.c$$' | awk '{print "SRCS += " $$1}' > $(FILE_MK)
 	cat $(FILE_TMP) | grep 'gcc ' | head -n 1 | grep -o " -I[^ ]*" | awk '{print "CFLAGS += " $$1}' >> $(FILE_MK)
 	rm $(FILE_TMP)
-	if [ "`sed -n '3p' $^`"x = x ]; then sed -i -e '2a#include "extra.h"' $^; fi
 
 menuconfig:
 	scons --menuconfig


### PR DESCRIPTION
在 rt-thread/bsp/abstract-machine 下执行 make -B 会导致 rtconfig.h 重新生成
但是在 rtconfig.h 加入 #include "extra.h" 这一步是在 init 中的.
这就导致了make -B生成的 rtconfig.h  缺失了这一行. 进而导致编译失败. 