### PR TITLE
使用编译选项实现自动make update

### DIFF
--- a/bsp/abstract-machine/.gitignore
+++ b/bsp/abstract-machine/.gitignore
@@ -1,3 +1,2 @@
 rtconfig.h
 files.mk
-am-apps.mk

--- a/bsp/abstract-machine/Makefile
+++ b/bsp/abstract-machine/Makefile
@@ -1,5 +1,6 @@
 ARCH ?= native
 FILE_MK = files.mk
+AM_APPS_MK = build/${ARCH}/am-apps.mk
 FILE_TMP = .tmp.$(FILE_MK)
 RTCONFIG_H = rtconfig.h
 
@@ -9,7 +10,9 @@ CFLAGS += -DHAVE_CCONFIG_H -D__RTTHREAD__
 CFLAGS += -Wno-nonnull-compare
 LDFLAGS += -T extra.ld
 -include $(FILE_MK)
--include am-apps.mk
+ifneq ($(AM_APPS),)
+include $(AM_APPS_MK)
+endif
 include $(AM_HOME)/Makefile
 
 $(RTCONFIG_H):
@@ -29,7 +32,9 @@ menuconfig:
 	scons --genconfig
 	$(MAKE) init
 
-update:
-	python integrate-am-apps.py ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE)
+$(AM_APPS_MK): integrate-am-apps.py
+	python3 integrate-am-apps.py ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE)
 
-.PHONY: init menuconfig
+update: $(AM_APP_MK)
+
+.PHONY: init menuconfig update

--- a/bsp/abstract-machine/integrate-am-apps.py
+++ b/bsp/abstract-machine/integrate-am-apps.py
@@ -27,7 +27,7 @@ if not sys.argv[2].startswith("CROSS_COMPILE="):
 CROSS_COMPILE = sys.argv[2][14:]
 
 Path("build").mkdir(exist_ok=True)
-am_app_mk_fp = open("am-apps.mk", "w")
+am_app_mk_fp = open(f"build/{ARCH}/am-apps.mk", "w")
 am_app_c_fp  = open("build/am-apps.c" , "w")
 lib_sym = [
   "memset", "memcpy", "memmove", "memcmp",


### PR DESCRIPTION
我的需求:
- 在 `git clone && make init` 后不需要 `make update` 就能编译链接am-apps到rtt
- 在`make ARCH=... ` 的ARCH选项发生改变后不需要手动的 `make ARCH=... update`  
  这在原来的rtt-am中会产生一个编译错误:
```
make: *** No rule to make target 'rt-thread-am/bsp/abstract-machine/build/${ARCH}/am-apps/hello/hello.o', needed by 'rt-thread-am/bsp/abstract-machine/build/rtthread-${ARCH}.elf'.  Stop.
```
- 在修改了 `integrate-am-apps.py` 后不需要手动的 `make update` 
- 在Makefile中使用 `python3` 而不是 `python` 
  python脚本中用的shell bang就是 `#!/usr/bin/env python3`,帮助中写的也是
```python
 if len(sys.argv) != 3:
    print("Usage: python3 integrate-am-apps.py ARCH=[AM arch] CROSS_COMPILE=[prefix]")
    exit(-1)
```
但是在makefile中用的却是python.这在我的系统(ubuntu 23.10)中已经会产生错误了  

---
我的修改:
- 增加一个编译选项 `AM_APPS` , 只在定义了 `AM_APPS` 时将 `am-apps` 的相关内容加入 `SRCS` 
- 将 `am-apps.mk ` 移动到 `build/${ARCH}/am-apps.mk` ,带来两个变化  
  1. `.gitignore` build中的内容不会被包含,因此删除 `am-apps.mk` 这一项  
  2. 各个 `ARCH` 下的 `am-apps` 不再互相影响,不会导致第二个需求中的错误  
- 将 `makefile` 中的 `python` 改为 `python3`

---  

修改在{rv32,rv32e,rv64}-nemu下从make clean开始测试,没有问题产生,在定义AM_APPS后rtt能够在help中识别出am-apps.在不定义AM_APPS的情况下,help不会显示am-apps.编译过程均正常,无新的错误产生.